### PR TITLE
Fix docs deployment in new projects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2


### PR DESCRIPTION
Note that clicking the "Use this template" button from the PR branch will create a new project WITHOUT the fix in place. The recommended steps to check this PR are:

Options:
1. Try it using my fork at [fyliu/admin-new-project-provisioning](https://github.com/fyliu/admin-new-project-provisioning). The change is the same but in [2 commits](https://github.com/hackforla/admin-new-project-provisioning/compare/main...fyliu:admin-new-project-provisioning:main). The new project should just deploy the documentation gh-pages without issues.
1. Using this repo
   1. Create a new repo from the template and apply the [2-line fix](https://github.com/hackforla/admin-new-project-provisioning/compare/main...fix-docs-deployment) manually to `ci.yml` 
   1. To check that the deployment works in the new project. Click into the failed initial deployment run in the Actions tab and click the "Re-run all jobs" button in the upper-right. The deployment should complete successfully. The docs should be viewable at https://hackforla.github.io/new-test-project-name/
   1. Approve and merge the fix. Check that a new project created with "Use this template" button has a successful initial deployment.

What it does:

Request repo write permission in `ci.yml` so it can commit the generated html docs into the gh-page branch.

This is better than setting a repo-wide permission since it's limited to this workflow only. It's set in the job, which is more limited than setting it for the workflow.

Code changes for #3