### PR TITLE
Fix docs deployment in new projects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2


### PR DESCRIPTION
Fixes #3

### What changes did you make?

- Added a line to request/get repo write permission in the ci script.

### Why did you make the changes (we will use this info to test)?

- The write permission is needed to write the docs to the gh-pages branch, which is needed for deployment.

### Before/After actions outputs

Actions -> ci (Initial Commit) -> deploy -> Run `mkdocs gh-deploy --force`

<details>
<summary>Output before changes are applied</summary>

```text
INFO    -  Copying '/home/runner/work/test-new-project5/test-new-project5/site' to 'gh-pages' branch and pushing to GitHub.
remote: Permission to fyliu/test-new-project5.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/fyliu/test-new-project5/': The requested URL returned error: 403
```

</details>

<details>
<summary>Output after changes are applied</summary>

```text
INFO    -  Copying '/home/runner/work/test-new-project2/test-new-project2/site' to 'gh-pages' branch and pushing to GitHub.
To https://github.com/fyliu/test-new-project2
 + cde3713...9ff[12](https://github.com/fyliu/test-new-project2/actions/runs/6856745882/job/18644517044#step:5:13)64 gh-pages -> gh-pages (forced update)
INFO    -  Your documentation should shortly be available at: https://fyliu.github.io/test-new-project2/
```

</details>

### How to test on GitHub

Try it using my fork at [fyliu/admin-new-project-provisioning](https://github.com/fyliu/admin-new-project-provisioning). This PR is made using that main branch so that the workflow can be tested using that repo. 

1. Generate a new project using the green "use this template" button. Be sure to select "include all branches" so it creates a gh-pages branch in the new repo to store the html docs output.
2. Click into the "Actions" tab and the first actions should complete successfully.
3. Click into the "Initial commit"/"ci" workflow and the "deploy" job and the "Run mkdocs gh-deploy --force" step. It should have a url for where to view the new docs. (See After output above for an example).